### PR TITLE
Fixes a regression of concentricColor and some typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ SHPieChartView
 ```objective-c
   SHPieChartView *normalPieChart = [[SHPieChartView alloc] initWithFrame:CGRectMake(10, 230, 150, 150)];
   
-  [normalPieChart addAngleValue:0.40 andClolor:[UIColor redColor]];
-  [normalPieChart addAngleValue:0.20 andClolor:[UIColor greenColor]];
-  [normalPieChart addAngleValue:0.30 andClolor:[UIColor blueColor]];
-  [normalPieChart addAngleValue:0.10 andClolor:[UIColor orangeColor]];
+  [normalPieChart addAngleValue:0.40 andColor:[UIColor redColor]];
+  [normalPieChart addAngleValue:0.20 andColor:[UIColor greenColor]];
+  [normalPieChart addAngleValue:0.30 andColor:[UIColor blueColor]];
+  [normalPieChart addAngleValue:0.10 andColor:[UIColor orangeColor]];
   
   [self.view addSubview:normalPieChart];
 ```
@@ -30,7 +30,7 @@ SHPieChartView
   concentricPieChart.concentricRadius = 70;
   concentricPieChart.concentricColor = UIColorFromRGB(0x54525C);
   
-  [concentricPieChart addAngleValue:0.40 andClolor:[UIColor redColor]];
+  [concentricPieChart addAngleValue:0.40 andColor:[UIColor redColor]];
 
   [self.view addSubview:concentricPieChart];
  ```
@@ -39,7 +39,7 @@ SHPieChartView
 
 ```objective-c
   SHPieChartView *halfChart = [[SHPieChartView alloc] initWithFrame:CGRectMake(10, 400, 100, 100)];
-  [halfChart addAngleValue:0.40 andClolor:UIColorFromRGB(0x3C60A3)];
+  [halfChart addAngleValue:0.40 andColor:UIColorFromRGB(0x3C60A3)];
   
   [self.view addSubview:halfChart];
 ```

--- a/SHPieChartView/SHPieChartView/SHPieChartView.h
+++ b/SHPieChartView/SHPieChartView/SHPieChartView.h
@@ -63,7 +63,7 @@
  *  @param color    the color of the pie
  *  @param index    the index at which you want to add the pie
  */
-- (void)insertAngleValue:(CGFloat)angle andClolor:(UIColor *)color atIndex:(int)index;
+- (void)insertAngleValue:(CGFloat)angle andColor:(UIColor *)color atIndex:(int)index;
 
 
 /**

--- a/SHPieChartView/SHPieChartView/SHPieChartView.h
+++ b/SHPieChartView/SHPieChartView/SHPieChartView.h
@@ -54,7 +54,7 @@
  *  @param angle    add the value between 0-1 to add a specific pie
  *  @param color    the color of the pie
  */
-- (void)addAngleValue:(CGFloat)angle andClolor:(UIColor *)color;
+- (void)addAngleValue:(CGFloat)angle andColor:(UIColor *)color;
 
 /**
  *  this method will insert the new pie in the pie chart instead of just adding it at the last place

--- a/SHPieChartView/SHPieChartView/SHPieChartView.m
+++ b/SHPieChartView/SHPieChartView/SHPieChartView.m
@@ -138,10 +138,10 @@ void createAndFillArc(CGContextRef context, CGPathRef path, CGColorRef color) {
   CGContextDrawPath(context, kCGPathFill);
 }
 
-CGMutablePathRef createArc(CGPoint center, CGFloat radius, CGFloat startAngle, CGFloat endAndle) {
+CGMutablePathRef createArc(CGPoint center, CGFloat radius, CGFloat startAngle, CGFloat endAngle) {
   CGMutablePathRef path = CGPathCreateMutable();
   
-  CGPathAddArc(path, NULL, center.x, center.y, radius, startAngle, endAndle, 0);
+  CGPathAddArc(path, NULL, center.x, center.y, radius, startAngle, endAngle, 0);
   CGPathAddLineToPoint(path, NULL, center.x, center.y);
   CGPathCloseSubpath(path);
   

--- a/SHPieChartView/SHPieChartView/SHPieChartView.m
+++ b/SHPieChartView/SHPieChartView/SHPieChartView.m
@@ -132,7 +132,7 @@
 }
 
 void createAndFillArc(CGContextRef context, CGPathRef path, CGColorRef color) {
-  CGContextSetFillColor(context, CGColorGetComponents(color));
+  CGContextSetFillColorWithColor(context, color);
   CGContextAddPath(context, path);
   
   CGContextDrawPath(context, kCGPathFill);

--- a/SHPieChartView/SHPieChartView/SHPieChartView.m
+++ b/SHPieChartView/SHPieChartView/SHPieChartView.m
@@ -76,7 +76,7 @@
   [self setNeedsDisplay];
 }
 
-- (void)insertAngleValue:(CGFloat)angle andClolor:(UIColor *)color atIndex:(int)index;
+- (void)insertAngleValue:(CGFloat)angle andColor:(UIColor *)color atIndex:(int)index;
 {
   ArcValueClass *v = [[ArcValueClass alloc] init];
   v.color = color;

--- a/SHPieChartView/SHPieChartView/SHPieChartView.m
+++ b/SHPieChartView/SHPieChartView/SHPieChartView.m
@@ -65,7 +65,7 @@
 
 #pragma mark - Pie addition methods
 
-- (void)addAngleValue:(CGFloat)angle andClolor:(UIColor *)color;
+- (void)addAngleValue:(CGFloat)angle andColor:(UIColor *)color;
 {
   ArcValueClass *v = [[ArcValueClass alloc] init];
   v.color = color;


### PR DESCRIPTION
Thanks for this nice tool :+1: 
I found and fixed a bug that prevented using a gray-scale color (like [UIColor whiteColor]) as the concentricColor.
Also I fixed a typo in the public method name and one in a private function.
